### PR TITLE
Remove white space padding in plot.

### DIFF
--- a/clapy.py
+++ b/clapy.py
@@ -226,6 +226,6 @@ def web_fit(times,datas,ncells):
     plt.ylabel('labeling fraction')
 
     image = io.BytesIO()
-    fig.savefig(image,format='png')
+    fig.savefig(image, format='png', bbox_inches='tight')
     plt.close(fig)
     return fit,image.getvalue()


### PR DESCRIPTION
White space around the plot makes it harder to configure proper layouts when included in websites or documents, thus should be removed.